### PR TITLE
URL changes & fixes

### DIFF
--- a/Fundamentals/tutorial.ipynb
+++ b/Fundamentals/tutorial.ipynb
@@ -706,10 +706,10 @@
     "\n",
     "The namelist defines two regions, in `INIT_PARAMS`; a background 'square' low-pressure region of 0.1 hydrogen atom per cubic centimetre, defined via the `d_region` parameter, and a 'point' region where energy is injected via the `p_region` parameter. Note that for the 'square' region, `p_region` is interpreted as a pressure, i.e. energy per unit volume, but for the 'point' region it is just an energy (i.e. not per volume). The `d_region` and `p_region` values are given in *code units*, and the exercise is to see how they convert to more understandable units like CGS.\n",
     "\n",
-    "In RAMSES this conversion is made with the three base units, which are also given in the namelist. Each of these converts a RAMSES variable, in code units, to cgs units. In other words, you multiply a density given by RAMSES, with `units_density` to convert to $\\rm{ g /cm^3}$, you multiply a length in RAMSES with `units_length` to convert to $\\rm cm$ and a time with `units_time` to convert to seconds. For example, you can find that the box length of 1 given in code units in the namelist corresponds to 1 kpc and that the initial homogeneous density given by `d_region` corresponds to $1.66 \\times 10^{−25} \\ {\\rm g / cm^3}$. Any unit conversion can be derived from these three basic units. For example, speed is converted from code units to $\\rm cm/s$ with\n",
+    "In RAMSES this conversion is made with the three base units, which are also given in the namelist. Each of these converts a RAMSES variable, in code units, to cgs units. In other words, you multiply a density given by RAMSES, with `units_density` to convert to $\\rm{ g /cm^3}$, you multiply a length in RAMSES with `units_length` to convert to $\\rm cm$ and a time with `units_time` to convert to seconds. For example, you can find that the box length of 1 given in code units in the namelist corresponds to 1 kpc and that the initial homogeneous density given by `d_region` corresponds to $1.66 \\times 10^{-25} \\ {\\rm g / cm^3}$. Any unit conversion can be derived from these three basic units. For example, speed is converted from code units to $\\rm cm/s$ with\n",
     "$$ \\rm units\\_v = units\\_length / units\\_time $$\n",
     "\n",
-    "I now leave it to you to derive how the value of `p_region`$= 8.6 \\times 10^{−7}$ in the Sedov namelist corresponds to $10^{51}$ ergs. Keep in mind that `p_region` indicates a pressure $p$ and you want to derive an energy $e$, and the two are related via \n",
+    "I now leave it to you to derive how the value of `p_region`$= 8.6 \\times 10^{-7}$ in the Sedov namelist corresponds to $10^{51}$ ergs. Keep in mind that `p_region` indicates a pressure $p$ and you want to derive an energy $e$, and the two are related via \n",
     "$$ p = e (\\gamma - 1), $$\n",
     "where $\\gamma= 1.4$ is the ratio of specific heats, also given in the namelist."
    ]
@@ -745,7 +745,7 @@
     "$$\n",
     "r_{\\rm I}(t) = r_{\\rm S} \\sqrt{1-e^{-t/t_{\\rm rec}}},\n",
     "$$\n",
-    "where $t_{\\rm rec} = \\left( n_{\\rm H} \\alpha^{\\rm B} \\right)^{−1}$ is the recombination time of the gas. \n",
+    "where $t_{\\rm rec} = \\left( n_{\\rm H} \\alpha^{\\rm B} \\right)^{-1}$ is the recombination time of the gas. \n",
     "(Pawlik & Schaye 2008,  showed that the analytic expression above for $r_{\\rm S}$ is actually too small by 5%, due to the approximation of a step function in the ionised fraction at the Strömgren radius.)\n",
     "\n",
     "### 5.1 Compare to the analytic Strömgren radius, with a reduced light speed\n",
@@ -801,7 +801,7 @@
    "source": [
     "\n",
     "The namelist (stromgren2d.nml) sets up an isotropic source of radiation, with a luminosity of $\\dot N = 2 \\times 10^{28}$\n",
-    "ionizing photons per second, in the corner of a 1 kpc wide cubic box. The homogeneous gas density is set to $n_{\\rm H} = 10^{−1} \\ {\\rm cm}^{−2}$. In the namelist, the `rt_TConst=1d4` parameter forces the temperature everywhere to $10^4$ K, which sets a constant recombination rate $\\alpha^{\\rm B} = 2.6 \\times 10^{-13} \\ \\rm s^{−1} \\rm cm^{2}$. From the equation above, we then get $r_{\\rm S} = 0.51$ kpc, the recombination time is $t_{\\rm rec} = 1.2$ Myr, and the Strömgren circle crossing time is $t_{\\rm cross} ≡ r_{\\rm S}/c = 1650$ years.\n",
+    "ionizing photons per second, in the corner of a 1 kpc wide cubic box. The homogeneous gas density is set to $n_{\\rm H} = 10^{-1} \\ {\\rm cm}^{-2}$. In the namelist, the `rt_TConst=1d4` parameter forces the temperature everywhere to $10^4$ K, which sets a constant recombination rate $\\alpha^{\\rm B} = 2.6 \\times 10^{-13} \\ \\rm s^{-1} \\rm cm^{2}$. From the equation above, we then get $r_{\\rm S} = 0.51$ kpc, the recombination time is $t_{\\rm rec} = 1.2$ Myr, and the Strömgren circle crossing time is $t_{\\rm cross} \\equiv r_{\\rm S}/c = 1650$ years.\n",
     "\n",
     "Now use the cell below to plot the results and compare the ionization front (or I-front) to the analytic expressions for $r_{\\rm S}$ and $r_{\\rm I}$, shown in red and yellow quarter-circles respectively. The I-front should converge towards the red circle and should do so following the time-evolution of the yellow quarter-circle."
    ]
@@ -883,7 +883,7 @@
    "source": [
     "In the setup given to you, the light speed has been reduced to one-thousandth of the actual light speed (with the namelist parameter `rt_c_fraction=0.001`). This is good for performance – the lower the light speed the larger the timestep and the faster the simulation – but as you can see in the output, it is not very good for accuracy, as the actual front is lagging well behind the analytic result shown with the yellow circle.\n",
     "\n",
-    "In the RAMSES-RT code paper (Rosdahl et al., 2013), we derive a framework for setting a minimum value for the reduced light speed, while still retaining accuracy. The light speed fraction should be set to $min\\left(1;∼ 10 \\times t_{\\rm cross}/\\tau_{\\rm sim}\\right)$ where $\\tau_{\\rm sim}$ is some simulation timescale within which we want to get an accurate I-front position. Use this expression to set a new (higher) value for the reduced light speed. Then verify that the I-front is accurately simulated within the timescale you choose (by comparing to the yellow expanding circle).\n",
+    "In the RAMSES-RT code paper (Rosdahl et al., 2013), we derive a framework for setting a minimum value for the reduced light speed, while still retaining accuracy. The light speed fraction should be set to $\\min\\left(1;\\sim 10 \\times t_{\\rm cross}/\\tau_{\\rm sim}\\right)$ where $\\tau_{\\rm sim}$ is some simulation timescale within which we want to get an accurate I-front position. Use this expression to set a new (higher) value for the reduced light speed. Then verify that the I-front is accurately simulated within the timescale you choose (by comparing to the yellow expanding circle).\n",
     "\n",
     "### 5.2 Turn on the photoionization heating of the gas\n",
     "\n",
@@ -988,7 +988,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,

--- a/doc/source/Setup/CBP.md
+++ b/doc/source/Setup/CBP.md
@@ -20,7 +20,7 @@ After this, **close the terminal**.
 ## 2. Download the ramses tutorials repository
 Open a new terminal and type the following:
 ```
-git clone https://github.com/blaizot/ramses-tutorials.git
+git clone https://github.com/ramses-organisation/ramses-tutorials.git
 ```
 
 ## 3. Install required python packages

--- a/doc/source/Setup/general_requirements.md
+++ b/doc/source/Setup/general_requirements.md
@@ -78,8 +78,7 @@ On top of thes general packages we will use more astro-specific packages to visu
 ### libraries
 Some third-party codes used in the tutorials require the following libraries: 
 - FFTW, which should be installed from the [fftw website](http://www.fftw.org). 
-- GSL, which should be installed from the [GSL
-  website](lhttp://www.gnu.org/software/gsl/). 
+- GSL, which should be installed from the [GSL website](lhttp://www.gnu.org/software/gsl/). 
 - FFMPEG will be used to generate videos.
 
 

--- a/doc/source/Setup/general_requirements.md
+++ b/doc/source/Setup/general_requirements.md
@@ -77,8 +77,8 @@ On top of thes general packages we will use more astro-specific packages to visu
 
 ### libraries
 Some third-party codes used in the tutorials require the following libraries: 
-- FFTW, which should be installed from the [fftw website](http://www.fftw.org). 
-- GSL, which should be installed from the [GSL website](lhttp://www.gnu.org/software/gsl/). 
+- FFTW, which should be installed from the [fftw website](https://www.fftw.org). 
+- GSL, which should be installed from the [GSL website](https://www.gnu.org/software/gsl/). 
 - FFMPEG will be used to generate videos.
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -65,7 +65,7 @@ secondary_color = '#FFD587'
 
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {
-    "repository_url": "https://github.com/blaizot/ramses-tutorials",
+    "repository_url": "https://github.com/ramses-organisation/ramses-tutorials",
     "repository_branch": "main",
     "use_repository_button": True,
     "use_issues_button": True,


### PR DESCRIPTION
This PR changes the URL of the git repo for the tutorials from `https://github.com/blaizot/ramses-tutorials.git` to `https://github.com/ramses-organisation/ramses-tutorials.git`, in an effort to base the RAMSES tutorials on the `ramses-organisation` version. This helps with Issue https://github.com/ramses-organisation/ramses-tutorials/issues/1 (at least partially).

In addition, this introduces some Unicode fixes in the "Fundamentals" tutorial (− converted to -, ≡ converted to `\\equiv`, ∼ converted to `\\sim`) to ensure that LaTeX compilation works smoothly.